### PR TITLE
✨ feat: add About page, unify app name, and refine UI

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "stable"
+  "flutter": "3.44.4"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:label="NationalGayAlliance"
+        android:label="FNGA"
         android:requestLegacyExternalStorage="true"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning"
         tools:replace="android:label">

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>NationalGayAlliance</string>
+	<string>FNGA</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/ui/page/home/home_page.dart
+++ b/lib/ui/page/home/home_page.dart
@@ -74,7 +74,7 @@ class _HomePageContent extends HookConsumerWidget {
   }
 
   String _getTitleText(int index) {
-    const titles = ['NGA', '贴子收藏', '浏览历史', '短消息', '提醒信息'];
+    const titles = ['FNGA', '贴子收藏', '浏览历史', '短消息', '提醒信息'];
     return titles.elementAtOrNull(index) ?? '';
   }
 

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = NationalGayAlliance
+PRODUCT_NAME = FNGA
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = io.github.loshine.flutterNga

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "NationalGayAlliance",
-    "short_name": "NGA",
+    "name": "FNGA",
+    "short_name": "FNGA",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "io.github.loshine" "\0"
-            VALUE "FileDescription", "NationalGayAlliance" "\0"
+            VALUE "FileDescription", "FNGA" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "NationalGayAlliance" "\0"
+            VALUE "InternalName", "FNGA" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 io.github.loshine. All rights reserved." "\0"
-            VALUE "OriginalFilename", "NationalGayAlliance.exe" "\0"
-            VALUE "ProductName", "NationalGayAlliance" "\0"
+            VALUE "OriginalFilename", "FNGA.exe" "\0"
+            VALUE "ProductName", "FNGA" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
## ✨ feat: 新增关于页面并统一应用名称、UI 规范

### What's changed

- ✨ **新增关于页面**：基于 Riverpod FutureProvider + `package_info_plus 9.0.0` 动态读取应用信息，版权年份使用 `DateTime.now().year`，无卡片样式符合项目 UI 规范
- 🏷️ **统一全平台应用名**：Android / iOS / macOS / Windows / Web 一致显示为 NationalGayAlliance，并配置关于页路由与 HomeDrawer 入口
- 🐛 **修复短消息详情页空白**：`MessageListData.fromJson` 改从 `allmsgs` 字段取数，补充 `userInfo` / `allmsgs` 空值保护
- ♻️ **全量 `super.key` 迁移**：67 个 Widget 构造函数移除冗余 `Key? key` 与 `super(key: key)`，净减 18 行
- 💄 **列表项扁平化**：历史 / 会话 / 通知列表项移除 Card，改用 Divider 分隔，与主话题列表视觉对齐

### Dependency / Build
- ➕ `package_info_plus: ^9.0.0`
- ⬆️ Android Gradle Plugin → 8.13.1

### Stats
- 4 commits · ~95 files · +705 / -513

### Test plan
- [x] 全平台启动显示应用名为 FNGA
- [x] HomeDrawer → 关于页面 正常打开，应用信息显示正确
- [x] 短消息详情页内容可正常渲染（回归 `f70d085` 修复场景）
- [x] 历史 / 会话 / 通知列表外观与话题列表风格一致
- [x] `fvm flutter analyze` 无新增告警